### PR TITLE
update to clear platform support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,9 @@ gify('out.mp4', 'out.gif', opts, function(err){
  - `start` start position in seconds or hh:mm:ss[.xxx] [0]
  - `duration` length of video to convert in seconds or hh:mm:ss[.xxx] [auto]
 
+## Notice
+- This module doesn't support *Windows*, because it uses shell-escape, which doesn't support Windows till now.
+
 # License
 
   MIT


### PR DESCRIPTION
As I write in it.
The support for Windows of shell-escape is shelved now.

The path within `*` will cause error as sec path of `gm convert`